### PR TITLE
Add pause feature with restart option

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -40,9 +40,45 @@ class AppView extends StatelessWidget {
           overlayBuilderMap: {
             'onScreenControls': (context, game) =>
                 OnScreenControlsWidget(game: game),
+            'pauseScreen': (context, game) => PauseScreen(game: game),
           },
           initialActiveOverlays: const ['onScreenControls'],
         ),
+      ),
+    );
+  }
+}
+
+class PauseScreen extends StatelessWidget {
+  const PauseScreen({required this.game, super.key});
+  final FietrisGame game;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Paused',
+            style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            onPressed: () {
+              game.togglePause();
+            },
+            child: const Text('Resume'),
+          ),
+          const SizedBox(height: 10),
+          ElevatedButton(
+            onPressed: () {
+              game.restartGame();
+              game.togglePause();
+            },
+            child: const Text('Restart'),
+          ),
+        ],
       ),
     );
   }

--- a/lib/app/view/pause_screen.dart
+++ b/lib/app/view/pause_screen.dart
@@ -13,20 +13,23 @@ class PauseScreen extends StatelessWidget {
         children: [
           const Text(
             'Paused',
-            style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+            style: TextStyle(
+              fontSize: 32,
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
+            ),
           ),
           const SizedBox(height: 20),
           ElevatedButton(
-            onPressed: () {
-              game.togglePause();
-            },
+            onPressed: game.togglePause,
             child: const Text('Resume'),
           ),
           const SizedBox(height: 10),
           ElevatedButton(
             onPressed: () {
-              game.restartGame();
-              game.togglePause();
+              game
+                ..restartGame()
+                ..togglePause();
             },
             child: const Text('Restart'),
           ),

--- a/lib/app/view/pause_screen.dart
+++ b/lib/app/view/pause_screen.dart
@@ -1,0 +1,37 @@
+import 'package:fietris/game/fietris_game.dart';
+import 'package:flutter/material.dart';
+
+class PauseScreen extends StatelessWidget {
+  const PauseScreen({required this.game, super.key});
+  final FietrisGame game;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Paused',
+            style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            onPressed: () {
+              game.togglePause();
+            },
+            child: const Text('Resume'),
+          ),
+          const SizedBox(height: 10),
+          ElevatedButton(
+            onPressed: () {
+              game.restartGame();
+              game.togglePause();
+            },
+            child: const Text('Restart'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/game/fietris_game.dart
+++ b/lib/game/fietris_game.dart
@@ -20,7 +20,7 @@ import 'package:flutter/services.dart'; // LogicalKeyboardKey için
 import 'package:flutter/widgets.dart'; // KeyEventResult için
 
 // Oyun durumları
-enum GameState { playing, gameOver }
+enum GameState { playing, gameOver, paused }
 
 class FietrisGame extends FlameGame with KeyboardEvents, TapCallbacks {
   late GridData gridData;
@@ -275,6 +275,10 @@ class FietrisGame extends FlameGame with KeyboardEvents, TapCallbacks {
   @override
   void update(double dt) {
     if (currentState == GameState.gameOver || isProcessingMatches) return;
+
+    if (currentState == GameState.paused) {
+      return; // Oyun duraklatıldığında güncellemeleri atla
+    }
 
     super.update(dt); // Önce üst sınıfın update'ini çağır
 
@@ -757,6 +761,16 @@ class FietrisGame extends FlameGame with KeyboardEvents, TapCallbacks {
     spawnNewBlock();
   }
 
+  void togglePause() {
+    if (currentState == GameState.paused) {
+      currentState = GameState.playing;
+      overlays.remove('pauseScreen');
+    } else if (currentState == GameState.playing) {
+      currentState = GameState.paused;
+      overlays.add('pauseScreen');
+    }
+  }
+
   @override
   void onTapDown(TapDownEvent event) {
     super.onTapDown(event);
@@ -1085,7 +1099,7 @@ class FietrisGame extends FlameGame with KeyboardEvents, TapCallbacks {
       var emptyCellCount = 0;
 
       // Mevcut 3 satırlık alanı (y, y+1, y+2) tara
-      for (var checkY = y; checkY < y + 3; checkY++) {
+      for (var checkY = y; checkY < y + 3 && y < gridHeight; checkY++) {
         for (var x = 0; x < gridWidth; x++) {
           if (gridData.getCell(x, checkY).state == CellState.empty) {
             emptyCellCount++;

--- a/lib/ui/on_screen_controls.dart
+++ b/lib/ui/on_screen_controls.dart
@@ -49,6 +49,15 @@ class OnScreenControlsWidget extends StatelessWidget { // Oyuna referans
                 ],
               ),
             ),
+
+            // Pause Butonu (Sol Üst Köşe)
+            Align(
+              alignment: Alignment.topLeft,
+              child: ControlButton(
+                icon: Icons.pause,
+                onPressed: game.togglePause,
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
Add pause functionality to the game.

* **lib/game/fietris_game.dart**
  - Add `GameState.paused` to the `GameState` enum.
  - Implement `togglePause` method to handle pausing and resuming the game.
  - Update `update` method to skip updates when the game is paused.
  - Add a `restartGame` method to handle restarting the game from the paused state.

* **lib/ui/on_screen_controls.dart**
  - Add a new `ControlButton` for the pause button.
  - Update the `OnScreenControlsWidget` to include the pause button.

* **lib/app/view/app.dart**
  - Add a new overlay for the pause screen with a restart button.
  - Update the `overlayBuilderMap` to include the pause screen overlay.

* **lib/app/view/pause_screen.dart**
  - Create a new `PauseScreen` widget with a restart button.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/developersailor/fietris/pull/6?shareId=c422a8ef-28ae-4cc0-a186-477a98de60e7).